### PR TITLE
Http basic auth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,10 @@
 			<artifactId>modelmapper</artifactId>
 			<version>0.7.4</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
     </dependencies>
 
 	<build>

--- a/src/main/java/com/blibli/future/detroit/configuration/DataSeeder.java
+++ b/src/main/java/com/blibli/future/detroit/configuration/DataSeeder.java
@@ -1,0 +1,42 @@
+package com.blibli.future.detroit.configuration;
+
+import com.blibli.future.detroit.model.User;
+import com.blibli.future.detroit.model.UserRole;
+import com.blibli.future.detroit.model.enums.UserType;
+import com.blibli.future.detroit.repository.UserRepository;
+import com.blibli.future.detroit.repository.UserRoleRepository;
+import com.blibli.future.detroit.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DataSeeder implements ApplicationRunner {
+
+    private UserRepository userRepository;
+    private UserRoleRepository userRoleRepository;
+
+    @Autowired
+    public DataSeeder(UserRepository userRepository,
+                      UserRoleRepository userRoleRepository) {
+        this.userRepository = userRepository;
+        this.userRoleRepository = userRoleRepository;
+    }
+
+    public void run(ApplicationArguments args) {
+        User agent = new User();
+        agent.setEmail("agent@example.com");
+        agent.setNickname("agent");
+        agent.setFullname("Agent Nomor 1");
+        agent.setGender("Male");
+        agent.setPassword("secret");
+        agent.setChannel("social media");
+        agent.setUserType(UserType.AGENT);
+        userRepository.save(agent);
+
+        UserRole agentRole = new UserRole(
+            agent.getEmail(), agent.getUserType().toString());
+        userRoleRepository.save(agentRole);
+    }
+}

--- a/src/main/java/com/blibli/future/detroit/configuration/DataSeeder.java
+++ b/src/main/java/com/blibli/future/detroit/configuration/DataSeeder.java
@@ -5,7 +5,6 @@ import com.blibli.future.detroit.model.UserRole;
 import com.blibli.future.detroit.model.enums.UserType;
 import com.blibli.future.detroit.repository.UserRepository;
 import com.blibli.future.detroit.repository.UserRoleRepository;
-import com.blibli.future.detroit.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
@@ -25,6 +24,7 @@ public class DataSeeder implements ApplicationRunner {
     }
 
     public void run(ApplicationArguments args) {
+        // API KEY = YWdlbnRAZXhhbXBsZS5jb206c2VjcmV0
         User agent = new User();
         agent.setEmail("agent@example.com");
         agent.setNickname("agent");

--- a/src/main/java/com/blibli/future/detroit/configuration/GlobalAuthenticationConfiguration.java
+++ b/src/main/java/com/blibli/future/detroit/configuration/GlobalAuthenticationConfiguration.java
@@ -1,0 +1,53 @@
+package com.blibli.future.detroit.configuration;
+
+import com.blibli.future.detroit.model.UserRole;
+import com.blibli.future.detroit.repository.UserRepository;
+import com.blibli.future.detroit.repository.UserRoleRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.authentication.configurers.GlobalAuthenticationConfigurerAdapter;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import java.util.List;
+
+@Configuration
+class GlobalAuthenticationConfiguration extends GlobalAuthenticationConfigurerAdapter {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    UserRoleRepository userRoleRepository;
+
+    @Override
+    public void init(AuthenticationManagerBuilder auth) throws Exception {
+        auth.userDetailsService(userDetailsService());
+    }
+
+    @Bean
+    UserDetailsService userDetailsService() {
+        return new UserDetailsService() {
+
+            @Override
+            public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+                com.blibli.future.detroit.model.User user = userRepository.findByEmail(email);
+                List<UserRole> userRoleList = userRoleRepository.findByEmail(email);
+                if(user != null) {
+                    return new User(user.getEmail(), user.getPassword(),
+                        true, true, true, true,
+                        AuthorityUtils.createAuthorityList("Agent"));
+                } else {
+                    throw new UsernameNotFoundException("Could not find the user '"
+                        + email + "'");
+                }
+            }
+
+        };
+    }
+}

--- a/src/main/java/com/blibli/future/detroit/configuration/WebSecurityConfiguration.java
+++ b/src/main/java/com/blibli/future/detroit/configuration/WebSecurityConfiguration.java
@@ -1,0 +1,27 @@
+package com.blibli.future.detroit.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@EnableWebSecurity
+@Configuration
+class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.authorizeRequests()
+            .antMatchers("/api/**")
+                .fullyAuthenticated()
+            .antMatchers("/api/v1/api-docs")
+                .permitAll()
+            .anyRequest()
+                .permitAll()
+            .and()
+                .httpBasic()
+            .and()
+                .csrf().disable();
+    }
+
+}

--- a/src/main/java/com/blibli/future/detroit/configuration/WebSecurityConfiguration.java
+++ b/src/main/java/com/blibli/future/detroit/configuration/WebSecurityConfiguration.java
@@ -1,12 +1,14 @@
 package com.blibli.future.detroit.configuration;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 
 @EnableWebSecurity
 @Configuration
+@Profile(value = {"development", "production"})
 class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Override

--- a/src/main/java/com/blibli/future/detroit/model/User.java
+++ b/src/main/java/com/blibli/future/detroit/model/User.java
@@ -20,6 +20,7 @@ public class User {
     private String fullname;
     private String nickname;
     private String email;
+    private String password;
     private String channel;
     private String teamLeader;
     private String dateOfBirth;
@@ -57,6 +58,14 @@ public class User {
 
     public void setEmail(String email) {
         this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
     }
 
     public String getChannel() {

--- a/src/main/java/com/blibli/future/detroit/model/User.java
+++ b/src/main/java/com/blibli/future/detroit/model/User.java
@@ -6,7 +6,10 @@ import com.blibli.future.detroit.model.enums.UserType;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import java.util.List;
 
 @Entity
 @Table(name = "detroit_users")
@@ -15,43 +18,6 @@ public class User {
     @GeneratedValue
     private Long id;
     private String fullname;
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        User user = (User) o;
-
-        if (!id.equals(user.id)) return false;
-        if (fullname != null ? !fullname.equals(user.fullname) : user.fullname != null) return false;
-        if (nickname != null ? !nickname.equals(user.nickname) : user.nickname != null) return false;
-        if (!email.equals(user.email)) return false;
-        if (channel != null ? !channel.equals(user.channel) : user.channel != null) return false;
-        if (teamLeader != null ? !teamLeader.equals(user.teamLeader) : user.teamLeader != null) return false;
-        if (dateOfBirth != null ? !dateOfBirth.equals(user.dateOfBirth) : user.dateOfBirth != null) return false;
-        if (gender != null ? !gender.equals(user.gender) : user.gender != null) return false;
-        if (location != null ? !location.equals(user.location) : user.location != null) return false;
-        if (phoneNumber != null ? !phoneNumber.equals(user.phoneNumber) : user.phoneNumber != null) return false;
-        return userType == user.userType;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = id.hashCode();
-        result = 31 * result + (fullname != null ? fullname.hashCode() : 0);
-        result = 31 * result + (nickname != null ? nickname.hashCode() : 0);
-        result = 31 * result + email.hashCode();
-        result = 31 * result + (channel != null ? channel.hashCode() : 0);
-        result = 31 * result + (teamLeader != null ? teamLeader.hashCode() : 0);
-        result = 31 * result + (dateOfBirth != null ? dateOfBirth.hashCode() : 0);
-        result = 31 * result + (gender != null ? gender.hashCode() : 0);
-        result = 31 * result + (location != null ? location.hashCode() : 0);
-        result = 31 * result + (phoneNumber != null ? phoneNumber.hashCode() : 0);
-        result = 31 * result + userType.hashCode();
-        return result;
-    }
-
     private String nickname;
     private String email;
     private String channel;
@@ -61,6 +27,9 @@ public class User {
     private String location;
     private String phoneNumber;
     private UserType userType;
+    @OneToMany
+    @JoinColumn(name = "email", referencedColumnName = "email")
+    private List<UserRole> userRole;
 
     public Long getId() {
         return id;
@@ -160,5 +129,50 @@ public class User {
 
     public boolean isSuperAdmin() {
         return this.userType.equals(UserType.SUPER_ADMIN);
+    }
+
+    public List<UserRole> getUserRole() {
+        return userRole;
+    }
+
+    public void setUserRole(List<UserRole> userRole) {
+        this.userRole = userRole;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        User user = (User) o;
+
+        if (!id.equals(user.id)) return false;
+        if (fullname != null ? !fullname.equals(user.fullname) : user.fullname != null) return false;
+        if (nickname != null ? !nickname.equals(user.nickname) : user.nickname != null) return false;
+        if (!email.equals(user.email)) return false;
+        if (channel != null ? !channel.equals(user.channel) : user.channel != null) return false;
+        if (teamLeader != null ? !teamLeader.equals(user.teamLeader) : user.teamLeader != null) return false;
+        if (dateOfBirth != null ? !dateOfBirth.equals(user.dateOfBirth) : user.dateOfBirth != null) return false;
+        if (gender != null ? !gender.equals(user.gender) : user.gender != null) return false;
+        if (location != null ? !location.equals(user.location) : user.location != null) return false;
+        if (phoneNumber != null ? !phoneNumber.equals(user.phoneNumber) : user.phoneNumber != null) return false;
+        return userType == user.userType;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = id.hashCode();
+        result = 31 * result + (fullname != null ? fullname.hashCode() : 0);
+        result = 31 * result + (nickname != null ? nickname.hashCode() : 0);
+        result = 31 * result + email.hashCode();
+        result = 31 * result + (channel != null ? channel.hashCode() : 0);
+        result = 31 * result + (teamLeader != null ? teamLeader.hashCode() : 0);
+        result = 31 * result + (dateOfBirth != null ? dateOfBirth.hashCode() : 0);
+        result = 31 * result + (gender != null ? gender.hashCode() : 0);
+        result = 31 * result + (location != null ? location.hashCode() : 0);
+        result = 31 * result + (phoneNumber != null ? phoneNumber.hashCode() : 0);
+        result = 31 * result + userType.hashCode();
+        return result;
     }
 }

--- a/src/main/java/com/blibli/future/detroit/model/User.java
+++ b/src/main/java/com/blibli/future/detroit/model/User.java
@@ -9,11 +9,12 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import java.io.Serializable;
 import java.util.List;
 
 @Entity
 @Table(name = "detroit_users")
-public class User {
+public class User implements Serializable {
     @Id
     @GeneratedValue
     private Long id;

--- a/src/main/java/com/blibli/future/detroit/model/UserRole.java
+++ b/src/main/java/com/blibli/future/detroit/model/UserRole.java
@@ -1,0 +1,46 @@
+package com.blibli.future.detroit.model;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class UserRole {
+    @Id
+    @GeneratedValue
+    private long id;
+    private String email;
+    private String role;
+
+    public UserRole() {
+    }
+
+    public UserRole(String email, String role) {
+        this.email = email;
+        this.role = role;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+}

--- a/src/main/java/com/blibli/future/detroit/repository/UserRepository.java
+++ b/src/main/java/com/blibli/future/detroit/repository/UserRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     List<User> findByUserType(UserType userType);
+    User findByEmail(String email);
 }

--- a/src/main/java/com/blibli/future/detroit/repository/UserRoleRepository.java
+++ b/src/main/java/com/blibli/future/detroit/repository/UserRoleRepository.java
@@ -1,0 +1,11 @@
+package com.blibli.future.detroit.repository;
+
+
+import com.blibli.future.detroit.model.UserRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserRoleRepository extends JpaRepository<UserRole, Long> {
+    List<UserRole> findByEmail(String email);
+}

--- a/src/main/java/com/blibli/future/detroit/service/UserService.java
+++ b/src/main/java/com/blibli/future/detroit/service/UserService.java
@@ -1,9 +1,12 @@
 package com.blibli.future.detroit.service;
 
 import com.blibli.future.detroit.model.User;
+import com.blibli.future.detroit.model.UserRole;
 import com.blibli.future.detroit.model.enums.UserType;
 import com.blibli.future.detroit.model.request.NewUserRequest;
 import com.blibli.future.detroit.repository.UserRepository;
+import com.blibli.future.detroit.repository.UserRoleRepository;
+import com.blibli.future.detroit.util.configuration.Converter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -14,6 +17,12 @@ public class UserService {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private UserRoleRepository userRoleRepository;
+
+    @Autowired
+    Converter modelMapper;
 
     public List<User> getAllUser() {
         return userRepository.findAll();
@@ -28,18 +37,14 @@ public class UserService {
     }
 
     public User createUser(NewUserRequest request) {
-        User newUser = new User();
-        newUser.setFullname(request.getFullname());
-        newUser.setNickname(request.getNickname());
-        newUser.setEmail(request.getEmail());
-        newUser.setChannel(request.getChannel());
-        newUser.setTeamLeader(request.getTeamLeader());
-        newUser.setDateOfBirth(request.getDateOfBirth());
-        newUser.setGender(request.getGender());
-        newUser.setLocation(request.getLocation());
-        newUser.setPhoneNumber(request.getPhoneNumber());
-        newUser.setUserType(request.getUserType());
-        userRepository.save(newUser);
+        User newUser = modelMapper.modelMapper()
+            .map(request, User.class);
+        newUser = userRepository.saveAndFlush(newUser);
+
+        UserRole role = new UserRole();
+        role.setEmail(newUser.getEmail());
+        role.setRole(newUser.getUserType().toString());
+        userRoleRepository.save(role);
 
         return newUser;
     }
@@ -51,16 +56,8 @@ public class UserService {
 
     public boolean updateUser(Long userId, NewUserRequest request) {
         // TODO throw error if userId doesn't exist
-        User user = userRepository.findOne(userId);
-        user.setFullname(request.getFullname());
-        user.setNickname(request.getNickname());
-        user.setEmail(request.getEmail());
-        user.setChannel(request.getChannel());
-        user.setTeamLeader(request.getTeamLeader());
-        user.setDateOfBirth(request.getDateOfBirth());
-        user.setGender(request.getGender());
-        user.setLocation(request.getLocation());
-        user.setPhoneNumber(request.getPhoneNumber());
+        User user = modelMapper.modelMapper()
+            .map(request, User.class);
         userRepository.save(user);
 
         return true;

--- a/src/main/java/com/blibli/future/detroit/util/TestHelper.java
+++ b/src/main/java/com/blibli/future/detroit/util/TestHelper.java
@@ -1,0 +1,19 @@
+package com.blibli.future.detroit.util;
+
+import com.blibli.future.detroit.model.enums.UserType;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class TestHelper {
+    public static void loginAsAgent() {
+        SecurityContextHolder.getContext().setAuthentication(
+            new TestingAuthenticationToken("Agent", "secret",
+                AuthorityUtils.createAuthorityList(UserType.AGENT.toString()))
+        );
+    }
+
+    public static void logout() {
+        SecurityContextHolder.clearContext();
+    }
+}

--- a/src/test/java/com/blibli/future/detroit/controller/api/CategoryControllerTest.java
+++ b/src/test/java/com/blibli/future/detroit/controller/api/CategoryControllerTest.java
@@ -9,12 +9,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatcher;
 import org.springframework.boot.context.embedded.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.ArrayList;
@@ -22,21 +21,15 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.jayway.restassured.RestAssured.given;
-import static com.jayway.restassured.RestAssured.objectMapper;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.isA;
-import static org.hamcrest.Matchers.samePropertyValuesAs;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.same;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ActiveProfiles(value = "test")
 public class CategoryControllerTest {
 
     @MockBean

--- a/src/test/java/com/blibli/future/detroit/controller/api/ParameterControllerTest.java
+++ b/src/test/java/com/blibli/future/detroit/controller/api/ParameterControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.context.embedded.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.ArrayList;
@@ -28,6 +29,7 @@ import static org.mockito.Mockito.when;
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ActiveProfiles(value = "test")
 public class ParameterControllerTest {
 
     @MockBean

--- a/src/test/java/com/blibli/future/detroit/controller/api/UserControllerTest.java
+++ b/src/test/java/com/blibli/future/detroit/controller/api/UserControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.context.embedded.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.Arrays;
@@ -25,6 +26,7 @@ import static org.mockito.Mockito.when;
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ActiveProfiles(value = "test")
 public class UserControllerTest {
     @MockBean
     private UserService userService;

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,4 @@
+# Disable security when unit testing
+security:
+  basic:
+    enabled: false


### PR DESCRIPTION
This implements API security via http basic auth.

@DitoRaharjo There is some changes that you should specifically know:

- Each request into API endpoints should providing user credential. 
  - For postman, see this guide https://www.getpostman.com/docs/helpers. 
  - For swagger-ui, fill `API_KEY` field on upper right page with `YWdlbnRAZXhhbXBsZS5jb206c2VjcmV0` (it's just base64 of `email:password`).
- For now, non API endpoint is not secured.
- On https://github.com/blibli-future/detroit/commit/95eec686d72f91502f0bd5a3eec6a399f7c9824a I create a simple database seeder script. You can expand this in the future to avoid manually POST some data into API before testing things each time.
- If you happen struggle with spring authentication in the future. I use user **email** as **spring "username"** (read here https://github.com/blibli-future/detroit/commit/45dae0fb0905fcea41ff3d2ba7b7cb77fdd9e9ed#diff-a82ea498f8a256fd42c59c54bab4402cR38). This is because spring by default expect us to use "username" as default user id/user handle. So this is the workaround.

Closes https://github.com/blibli-future/detroit/issues/8