### PR TITLE
Feature/frontend stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ nbdist/
 
 application.properties
 .mvn
+
+node_modules
+bundle.js
+bundle.js.map

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "detroit",
+  "version": "0.1.0",
+  "description": "Detroit customer service intelligence",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:blibli-future/detroit.git"
+  },
+  "dependencies": {
+    "react": "^15.3.2",
+    "react-dom": "^15.3.2",
+    "rest": "^1.3.1",
+    "webpack": "^1.12.2"
+  },
+  "scripts": {
+    "watch": "webpack --watch -d"
+  },
+  "devDependencies": {
+    "babel-core": "^6.18.2",
+    "babel-loader": "^6.2.7",
+    "babel-polyfill": "^6.16.0",
+    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-react": "^6.16.0"
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
@@ -86,6 +85,41 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+
+			<plugin>
+				<groupId>com.github.eirslett</groupId>
+				<artifactId>frontend-maven-plugin</artifactId>
+				<version>1.4</version>
+				<configuration>
+					<installDirectory>target</installDirectory>
+				</configuration>
+				<executions>
+					<execution>
+						<id>install node and npm</id>
+						<goals>
+							<goal>install-node-and-npm</goal>
+						</goals>
+						<configuration>
+							<nodeVersion>v6.10.2</nodeVersion>
+						</configuration>
+					</execution>
+					<execution>
+						<id>npm install</id>
+						<goals>
+							<goal>npm</goal>
+						</goals>
+						<configuration>
+							<arguments>install</arguments>
+						</configuration>
+					</execution>
+					<execution>
+						<id>webpack build</id>
+						<goals>
+							<goal>webpack</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/frontend/js/app.js
+++ b/src/main/frontend/js/app.js
@@ -1,0 +1,16 @@
+const React = require('react');
+const ReactDOM = require('react-dom');
+
+class App extends React.Component {
+
+    render() {
+        return (
+            <h1>Hello World</h1>
+        )
+    }
+}
+
+ReactDOM.render(
+    <App />,
+    document.getElementById('root')
+)

--- a/src/main/java/com/blibli/future/detroit/controller/view/DetroitViewController.java
+++ b/src/main/java/com/blibli/future/detroit/controller/view/DetroitViewController.java
@@ -1,0 +1,13 @@
+package com.blibli.future.detroit.controller.view;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+public class DetroitViewController {
+    @RequestMapping("/view")
+    public String homeView(Model model) {
+        return "index";
+    }
+}

--- a/src/main/resources/application.properties.example
+++ b/src/main/resources/application.properties.example
@@ -1,0 +1,1 @@
+spring.profiles.active = development

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,10 +1,19 @@
 <!DOCTYPE html>
-<html lang="en">
+
+<html xmlns:th="http://www.thymeleaf.org">
+
 <head>
-    <meta charset="UTF-8">
-    <title></title>
+    <title>Good Thymes Virtual Grocery</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 </head>
+
 <body>
 
+<div id="root"></div>
+
+<script src="/bundle.js"></script>
+
+
 </body>
+
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,25 @@
+var path = require('path');
+
+module.exports = {
+    entry: './src/main/frontend/js/app.js',
+    devtool: 'sourcemaps',
+    cache: true,
+    debug: true,
+    output: {
+        path: __dirname,
+        filename: './src/main/resources/static/bundle.js'
+    },
+    module: {
+        loaders: [
+            {
+                test: path.join(__dirname, '.'),
+                exclude: /(node_modules)/,
+                loader: 'babel',
+                query: {
+                    cacheDirectory: true,
+                    presets: ['es2015', 'react']
+                }
+            }
+        ]
+    }
+};


### PR DESCRIPTION
This PR enable our project to build react js application.

We use npm to "compile" (technically it's transpiling) react js file in [app.js](https://github.com/blibli-future/detroit/compare/develop...blibli-future:feature/frontend-stub?expand=1#diff-72b9ca58b5f04ff939e0e40d2d26d9ea) into a runnable script in `resource/bundle.js` that our Spring project will read and serve them to user browser.

The NPM build process (build refer to the whole transpiling, minifying, etc) could be run automatically via maven command, thanks to [frontend-maven-plugin](https://github.com/eirslett/frontend-maven-plugin)

Before you can run this, there are few "installation" step required:

0. Open cmd window and cd to detroit folder.
1. Install node via mvn:frontend plugin
   `mvn frontend:install-node-and-npm -DnodeVersion=v6.10.2`
2. Install library2 node (react, dll)
   `mvn frontend:npm`
3. Ubah konfigurasi jalannya Spring agar melakukan build react terlebih dahulu
   - Edit konfigurasi DetroitApplication (klik dropdown di tempat jalanin app biasanya itu)
   - Di bagian paling bawah (Before launch), klik tanda +
   - Pilih run maven goal
   - Di bagian `command line`, isi dengan `frontend:webpack`
   - OK
   - Ubah posisinya agar item ini jadi nomor 1
4. Jalankan project seperti biasanya
5. Buka http://localhost:8080/view/, jika sukses akan ada tulisann Hello World